### PR TITLE
Renaming: Composer -> Welder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Composer BDCS API Library and Server
+# BDCS API Library and Server
 
 This codebase is the BDCS API server, it handles API requests for project
 information, recipes, and image composing.

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,8 +1,8 @@
-//! Composer Recipe Functions
+//! Welder Recipe Functions
 //!
 //! ## Overview
 //!
-//! Composer recipes are stored as TOML formatted files in a git repository.
+//! Welder recipes are stored as TOML formatted files in a git repository.
 //! This module provides functions for listing, reading, and writing them.
 //!
 
@@ -102,7 +102,7 @@ impl From<toml::de::Error> for RecipeError {
 }
 
 
-/// Composer Recipe
+/// Welder Recipe
 ///
 /// This is used to parse the full recipe's TOML, and to write a JSON representation of
 /// the Recipe.


### PR DESCRIPTION
No code changes, but remove references to "Composer" and change them to
"Welder" where appropriate.