### PR TITLE
minor code cleanups

### DIFF
--- a/src/api/v0.rs
+++ b/src/api/v0.rs
@@ -29,7 +29,7 @@
 // You should have received a copy of the GNU General Public License
 // along with bdcs-api-server.  If not, see <http://www.gnu.org/licenses/>.
 
-use rocket::{config, State};
+use rocket::State;
 use rocket_contrib::JSON;
 
 // bdcs database functions
@@ -142,7 +142,7 @@ pub fn compose_cancel<'r>() -> CORS<&'static str> {
 /// * Change it to a meaningful error code and JSON response
 ///
 #[get("/compose/status")]
-pub fn compose_status<'r>() -> CORS<&'static str> {
+pub fn compose_status() -> CORS<&'static str> {
     CORS("Unimplemented")
 }
 
@@ -163,7 +163,7 @@ pub fn compose_status<'r>() -> CORS<&'static str> {
 /// * Change it to a meaningful error code and JSON response
 ///
 #[get("/compose/status/<id>")]
-pub fn compose_status_id<'r>(id: &str) -> CORS<&'static str> {
+pub fn compose_status_id(id: &str) -> CORS<&'static str> {
     CORS("Unimplemented")
 }
 
@@ -185,7 +185,7 @@ pub fn compose_status_id<'r>(id: &str) -> CORS<&'static str> {
 /// * Pass it the id of a running compose
 ///
 #[get("/compose/log/<kbytes>")]
-pub fn compose_log<'r>(kbytes: usize) -> CORS<&'static str> {
+pub fn compose_log(kbytes: usize) -> CORS<&'static str> {
     CORS("Unimplemented")
 }
 
@@ -516,7 +516,7 @@ pub fn modules_list_noargs_default(db: State<DBPool>) -> CORS<JSON<ModulesListRe
 /// ```
 ///
 pub fn modules_list(mut modules: &str, db: State<DBPool>, offset: i64, limit: i64) -> CORS<JSON<ModulesListResponse>> {
-    if modules.len() == 0 {
+    if modules.is_empty() {
         modules = "*";
     }
     info!("/modules/list/"; "modules" => modules, "offset" => offset, "limit" => limit);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ extern crate hyper;
 extern crate r2d2;
 extern crate r2d2_sqlite;
 extern crate rocket;
-#[macro_use] extern crate rocket_contrib;
+extern crate rocket_contrib;
 extern crate rusqlite;
 extern crate serde_json;
 #[macro_use] extern crate serde_derive;

--- a/tests/mock_tests.rs
+++ b/tests/mock_tests.rs
@@ -22,14 +22,12 @@ extern crate bdcs;
 extern crate rocket;
 extern crate toml;
 
-use std::fs::{File, remove_file};
-use std::io::{Read, Write};
-use std::path::Path;
+use std::fs::File;
+use std::io::Write;
 
 use bdcs::{RocketToml, RocketConfig};
 use bdcs::api::mock;
-use rocket::config;
-use rocket::http::{ContentType, Method, Status};
+use rocket::http::{Method, Status};
 use rocket::testing::MockRequest;
 
 
@@ -136,4 +134,3 @@ fn mock_route_action() {
     let body_str = response.body().and_then(|b| b.into_string());
     assert_eq!(body_str, Some(expected_filter.to_string()));
 }
-


### PR DESCRIPTION
- Remove unused imports
- Remove unnecessary lifetimes
- Remove unused "#[macro_use]"
- Use ".is_empty()" instead of ".len() == 0"