### PR TITLE
Add a mutable integer to the DepExpression RefCell

### DIFF
--- a/src/bin/depclose.rs
+++ b/src/bin/depclose.rs
@@ -11,7 +11,6 @@ use std::collections::HashMap;
 use std::env;
 use std::process::exit;
 use std::rc::Rc;
-use std::cell::RefCell;
 
 fn main() {
     let mut argv: Vec<String> = env::args().collect();
@@ -37,7 +36,7 @@ fn main() {
     };
 
     // Wrap the returned depexpression in the crud it needs
-    let mut exprs = vec![Rc::new(RefCell::new(depexpr))];
+    let mut exprs = vec![Rc::new(DepCell::new(depexpr))];
     let mut assignments = HashMap::new();
     unit_propagation(&mut exprs, &mut assignments);
  

--- a/src/depclose.rs
+++ b/src/depclose.rs
@@ -23,7 +23,8 @@ use std::fmt;
 use std::str::FromStr;
 use itertools::Itertools;
 use std::rc::Rc;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::ops::Deref;
 
 // TODO might need to mess with the type for depsolve
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -44,9 +45,9 @@ impl fmt::Display for DepAtom {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DepExpression {
     Atom(DepAtom),
-    And(Vec<Rc<RefCell<DepExpression>>>),
-    Or(Vec<Rc<RefCell<DepExpression>>>),
-    Not(Rc<RefCell<DepExpression>>)
+    And(Vec<Rc<DepCell<DepExpression>>>),
+    Or(Vec<Rc<DepCell<DepExpression>>>),
+    Not(Rc<DepCell<DepExpression>>)
 }
 
 impl fmt::Display for DepExpression {
@@ -61,6 +62,25 @@ impl fmt::Display for DepExpression {
                                                 },
             &DepExpression::Not(ref expr)    => write!(f, "NOT {}", *(expr.borrow()))
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct DepCell<T> {
+    pub marker: Cell<i64>,
+    pub cell: RefCell<T>
+}
+
+impl<T> DepCell<T> {
+    pub fn new(value: T) -> DepCell<T> {
+        DepCell {marker: Cell::new(-1), cell: RefCell::new(value) }
+    }
+}
+
+impl<T> Deref for DepCell<T> {
+    type Target = RefCell<T>;
+    fn deref(&self) -> &RefCell<T> {
+        &self.cell
     }
 }
 
@@ -83,7 +103,7 @@ fn group_matches_arch(conn: &Connection, group_id: i64, arches: &Vec<String>) ->
 }
 
 // Given a requirement, find a list of groups providing it and return all of that as an expression
-fn req_providers(conn: &Connection, arches: &Vec<String>, req: &Requirement, parents: &HashSet<i64>, cache: &mut HashMap<i64, Rc<RefCell<DepExpression>>>) -> Result<Option<Rc<RefCell<DepExpression>>>, String> {
+fn req_providers(conn: &Connection, arches: &Vec<String>, req: &Requirement, parents: &HashSet<i64>, cache: &mut HashMap<i64, Rc<DepCell<DepExpression>>>) -> Result<Option<Rc<DepCell<DepExpression>>>, String> {
     // helper function for converting a (Group, KeyVal) to Option<(group_id, Requirement)>
     fn provider_to_requirement(group: &Groups, kv: &KeyVal) -> Option<(i64, Requirement)> {
         let ext_val = match &kv.ext_value {
@@ -100,7 +120,7 @@ fn req_providers(conn: &Connection, arches: &Vec<String>, req: &Requirement, par
     }
 
     // gather child requirements if necessary
-    fn depclose_provider(conn: &Connection, arches: &Vec<String>, group_id: i64, parents: &HashSet<i64>, cache: &mut HashMap<i64, Rc<RefCell<DepExpression>>>) -> Result<Option<Rc<RefCell<DepExpression>>>, String> {
+    fn depclose_provider(conn: &Connection, arches: &Vec<String>, group_id: i64, parents: &HashSet<i64>, cache: &mut HashMap<i64, Rc<DepCell<DepExpression>>>) -> Result<Option<Rc<DepCell<DepExpression>>>, String> {
         if parents.contains(&group_id) {
             // This requirement is already satisfied, return
             Ok(None)
@@ -137,7 +157,7 @@ fn req_providers(conn: &Connection, arches: &Vec<String>, req: &Requirement, par
                                                  },
                                                  Err(_) => None
                                              })
-                                             .collect::<Vec<Rc<RefCell<DepExpression>>>>();
+                                             .collect::<Vec<Rc<DepCell<DepExpression>>>>();
 
             providers_checked
         },
@@ -173,7 +193,7 @@ fn req_providers(conn: &Connection, arches: &Vec<String>, req: &Requirement, par
         Ok(Some(group_providers[0].clone()))
     } else {
         // a choice among more than one provider
-        Ok(Some(Rc::new(RefCell::new(DepExpression::Or(group_providers)))))
+        Ok(Some(Rc::new(DepCell::new(DepExpression::Or(group_providers)))))
     }
 }
 
@@ -205,7 +225,7 @@ fn req_providers(conn: &Connection, arches: &Vec<String>, req: &Requirement, par
 // if everything it needs can be removed from the expression, so that a group id is effectively the
 // thing that can be turned on or off during solving.
 
-fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, parent_groups: &HashSet<i64>, cache: &mut HashMap<i64, Rc<RefCell<DepExpression>>>) -> Result<Rc<RefCell<DepExpression>>, String> {
+fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, parent_groups: &HashSet<i64>, cache: &mut HashMap<i64, Rc<DepCell<DepExpression>>>) -> Result<Rc<DepCell<DepExpression>>, String> {
     // If this value is cached, return it
     if let Some(expr) = cache.get(&group_id) {
         return Ok(expr.clone());
@@ -222,15 +242,15 @@ fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, pare
     let (group_provides, group_obsoletes, group_conflicts) = match get_groups_kv_group_id(conn, group_id) {
         Ok(group_key_vals) => {
             // map a key/value pair into a Requirement
-            fn kv_to_expr(kv: &KeyVal) -> Result<Rc<RefCell<DepExpression>>, String> {
+            fn kv_to_expr(kv: &KeyVal) -> Result<Rc<DepCell<DepExpression>>, String> {
                 match &kv.ext_value {
-                    &Some(ref ext_value) => Ok(Rc::new(RefCell::new(DepExpression::Atom(DepAtom::Requirement(try!(Requirement::from_str(ext_value.as_str()))))))),
+                    &Some(ref ext_value) => Ok(Rc::new(DepCell::new(DepExpression::Atom(DepAtom::Requirement(try!(Requirement::from_str(ext_value.as_str()))))))),
                     &None                => Err(String::from("ext_value is not set"))
                 }
             }
 
-            fn kv_to_not_expr(kv: &KeyVal) -> Result<Rc<RefCell<DepExpression>>, String> {
-                Ok(Rc::new(RefCell::new(DepExpression::Not(try!(kv_to_expr(kv))))))
+            fn kv_to_not_expr(kv: &KeyVal) -> Result<Rc<DepCell<DepExpression>>, String> {
+                Ok(Rc::new(DepCell::new(DepExpression::Not(try!(kv_to_expr(kv))))))
             }
 
             let mut group_provides = Vec::new();
@@ -247,9 +267,9 @@ fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, pare
             }
 
             // Collect the Vec<Result<Expression, String>>s into a Result<Vec<Expression>, String>
-            let group_provides_result: Result<Vec<Rc<RefCell<DepExpression>>>, String> = group_provides.into_iter().collect();
-            let group_obsoletes_result: Result<Vec<Rc<RefCell<DepExpression>>>, String> = group_obsoletes.into_iter().collect();
-            let group_conflicts_result: Result<Vec<Rc<RefCell<DepExpression>>>, String> = group_conflicts.into_iter().collect();
+            let group_provides_result: Result<Vec<Rc<DepCell<DepExpression>>>, String> = group_provides.into_iter().collect();
+            let group_obsoletes_result: Result<Vec<Rc<DepCell<DepExpression>>>, String> = group_obsoletes.into_iter().collect();
+            let group_conflicts_result: Result<Vec<Rc<DepCell<DepExpression>>>, String> = group_conflicts.into_iter().collect();
 
             // unwrap the result or return the error
             (try!(group_provides_result), try!(group_obsoletes_result), try!(group_conflicts_result))
@@ -264,7 +284,7 @@ fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, pare
             let gr_reqs: Vec<Requirement> = try!(requirements.iter().map(|r| Requirement::from_str(r.req_expr.as_str())).collect());
 
             // for each requirement, create an expression of (requirement AND requirement_providers)
-            let mut group_requirements: Vec<Rc<RefCell<DepExpression>>> = Vec::new();
+            let mut group_requirements: Vec<Rc<DepCell<DepExpression>>> = Vec::new();
             for r in gr_reqs.iter() {
                 // If only one group comes back as the requirement (i.e., there is only one
                 // provider for the requirement), that group can be skipped in additional
@@ -279,13 +299,13 @@ fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, pare
                 // things are processed in, but it should cut way down on extra copies of
                 // everything.
                 let providers = try!(req_providers(conn, arches, r, &parent_groups_copy, cache));
-                let req_expr  = Rc::new(RefCell::new(DepExpression::Atom(DepAtom::Requirement(r.clone()))));
+                let req_expr  = Rc::new(DepCell::new(DepExpression::Atom(DepAtom::Requirement(r.clone()))));
                 match providers {
                     Some(provider_exp) => {
-                        if Rc::new(RefCell::new(DepExpression::Atom(DepAtom::GroupId(group_id)))) == provider_exp {
+                        if Rc::new(DepCell::new(DepExpression::Atom(DepAtom::GroupId(group_id)))) == provider_exp {
                             parent_groups_copy.insert(group_id);
                         }
-                        group_requirements.push(Rc::new(RefCell::new(DepExpression::And(vec![req_expr, provider_exp]))));
+                        group_requirements.push(Rc::new(DepCell::new(DepExpression::And(vec![req_expr, provider_exp]))));
                     },
                     None => ()
                 };
@@ -296,24 +316,24 @@ fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, pare
     };
 
     let mut and_list = Vec::new();
-    and_list.push(Rc::new(RefCell::new(DepExpression::Atom(DepAtom::GroupId(group_id)))));
+    and_list.push(Rc::new(DepCell::new(DepExpression::Atom(DepAtom::GroupId(group_id)))));
     if !group_provides.is_empty() {
-        and_list.push(Rc::new(RefCell::new(DepExpression::And(group_provides))));
+        and_list.push(Rc::new(DepCell::new(DepExpression::And(group_provides))));
     }
 
     if !group_requirements.is_empty() {
-        and_list.push(Rc::new(RefCell::new(DepExpression::And(group_requirements))));
+        and_list.push(Rc::new(DepCell::new(DepExpression::And(group_requirements))));
     }
 
     if !group_obsoletes.is_empty() {
-        and_list.push(Rc::new(RefCell::new(DepExpression::And(group_obsoletes))));
+        and_list.push(Rc::new(DepCell::new(DepExpression::And(group_obsoletes))));
     }
 
     if !group_conflicts.is_empty() {
-        and_list.push(Rc::new(RefCell::new(DepExpression::And(group_conflicts))));
+        and_list.push(Rc::new(DepCell::new(DepExpression::And(group_conflicts))));
     }
 
-    Ok(Rc::new(RefCell::new(DepExpression::And(and_list))))
+    Ok(Rc::new(DepCell::new(DepExpression::And(and_list))))
 }
 
 pub fn close_dependencies(conn: &Connection, arches: &Vec<String>, packages: &Vec<String>) -> Result<DepExpression, String> {


### PR DESCRIPTION
Replace the RefCells with a struct that wraps the RefCell and adds a
Cell with an i64, which can be used by unit_propagation to tell whether
it has examined a given subexpression since the last change.