### PR TITLE
Rearrange tests (plus bonus cleanups)

### DIFF
--- a/src/bin/depclose.rs
+++ b/src/bin/depclose.rs
@@ -39,24 +39,13 @@ fn main() {
     // Wrap the returned depexpression in the crud it needs
     let mut exprs = vec![Rc::new(DepCell::new(depexpr))];
 
-    match solve_dependencies(&conn, &mut exprs) {
-        Ok(ids) => { let mut results = Vec::new();
-                     for id in ids {
-                         match get_groups_id(&conn, &id) {
-                             // Commented out for the moment - just printing group names is easier
-                             // to debug.
-                             // Ok(Some(grp)) => { let mut details = get_projects_details(&conn, &[grp.name.as_str()]).unwrap();
-                             //                    results.append(&mut details);
-                             //                  }
-                             Ok(Some(grp)) => { results.push(grp.name) }
-                             _ => { }
-                         }
-                     }
+    let results:Vec<bdcs::db::Groups> = solve_dependencies(&conn, &mut exprs)
+        .unwrap_or_else(|e| exit_error!(1, e)).iter()
+        .map(|id| get_groups_id(&conn, id))
+        .filter_map(|grp_res| grp_res.unwrap_or(None))
+        .collect();
 
-                     for x in results {
-                         println!("{}", x);
-                     }
-                   }
-        Err(e)  => { println!("{}", e); }
+    for grp in results {
+        println!("{}", grp.name);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -38,11 +38,6 @@ use r2d2;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{self, Connection};
 
-#[cfg(test)]
-#[path = "./db_test.rs"]
-pub mod db_test;
-
-
 /// Database pool connection, used with Rocket's managed state system
 pub struct DBPool(r2d2::Pool<SqliteConnectionManager>);
 impl DBPool {

--- a/src/depclose.rs
+++ b/src/depclose.rs
@@ -27,10 +27,6 @@ use std::rc::Rc;
 use std::cell::{Cell, RefCell};
 use std::ops::Deref;
 
-#[cfg(test)]
-#[path = "./depclose_test.rs"]
-mod depclose_test;
-
 // TODO might need to mess with the type for depsolve
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum DepAtom {

--- a/src/depclose.rs
+++ b/src/depclose.rs
@@ -175,7 +175,7 @@ fn req_providers(conn: &Connection, arches: &Vec<String>, req: &Requirement, par
             }
             // map the remaining providers to an expression, recursing to fetch the provider's requirements
             // any recursions that return Err unsatisfiable, so filter those out
-            providers_checked_2.iter().filter_map(|&(group_id, ref req)| match depclose_provider(conn, arches, group_id, parents, cache) {
+            providers_checked_2.iter().filter_map(|&(group_id, _)| match depclose_provider(conn, arches, group_id, parents, cache) {
                 Ok(Some(provider)) => {
                     // mark the requirement as satisfied
                     satisfied = true;
@@ -334,7 +334,7 @@ fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, pare
 
             match (name, version) {
                 (Some(name), Some(version)) => match EVR::from_str(version.as_str()) {
-                    Ok(evr) => { 
+                    Ok(evr) => {
                         let req = Requirement{name: "PKG: ".to_string() + name.as_str(),
                                               expr: Some((ReqOperator::EqualTo, evr))};
                         group_provides.push(Ok(wrap_requirement(req)));
@@ -372,7 +372,7 @@ fn depclose_package(conn: &Connection, arches: &Vec<String>, group_id: i64, pare
                 // requirements.
                 // For instance, if our expression so far is something like:
                 //    (req_1 AND (groupid=47 AND group_47_reqs)) AND (req_2 ...)
-                // 
+                //
                 // and req_2 is also satisified by groupid=47, we don't need another copy of
                 // groupid=47 and its requirements.
                 //

--- a/src/depsolve.rs
+++ b/src/depsolve.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::ops::Index;
 use std::ops::IndexMut;
 use std::rc::Rc;
-use std::cell::RefCell;
 
 pub fn solve_dependencies(conn: &Connection, exprs: &mut Vec<Rc<DepCell<DepExpression>>>) -> Result<Vec<i64>, String> {
     let mut assignments = HashMap::new();
@@ -18,7 +17,7 @@ pub fn solve_dependencies(conn: &Connection, exprs: &mut Vec<Rc<DepCell<DepExpre
     if exprs.is_empty() {
         // Take the DepAtom -> bool hash map and convert it to just a list of i64.  We only care
         // about the GroupId for packages that will be installed.
-        let mut results = assignments.into_iter().filter_map(|x| match x {
+        let results = assignments.into_iter().filter_map(|x| match x {
             (DepAtom::GroupId(i), true) => Some(i),
             _ => None
         }).collect();

--- a/src/rpm.rs
+++ b/src/rpm.rs
@@ -27,10 +27,6 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::str::FromStr;
 
-#[cfg(test)]
-#[path = "./rpm_test.rs"]
-mod rpm_test;
-
 /// Representation of epoch-version-release data
 #[derive(Clone, Debug, Hash)]
 pub struct EVR {

--- a/tests/rpm.rs
+++ b/tests/rpm.rs
@@ -17,7 +17,10 @@
 // You should have received a copy of the GNU General Public License
 // along with bdcs-api-server.  If not, see <http://www.gnu.org/licenses/>.
 
-use rpm::*;
+extern crate bdcs;
+
+use bdcs::rpm::{self, EVR, ReqOperator, Requirement, vercmp};
+use std::cmp::Ordering;
 
 #[test]
 fn test_evr_ord() {


### PR DESCRIPTION
The first commit moves tests of external interfaces into `tests/` (and cleans up a few things), and the other two commits just do some little code cleanups.