### PR TITLE
Use pretty_assertions when testing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ unicase = "1.*"
 
 [dev-dependencies]
 rocket = { version = "0.2.*", features = ["testing"] }
+pretty_assertions = "0.1.*"
 
 [features]
 # Treat warnings as build errors. Use for testing and CI!

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -20,6 +20,8 @@
 
 extern crate bdcs;
 #[macro_use] extern crate lazy_static;
+#[macro_use] extern crate pretty_assertions;
+
 extern crate rocket;
 extern crate serde_json;
 extern crate toml;

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -18,6 +18,7 @@
 // along with bdcs-api-server.  If not, see <http://www.gnu.org/licenses/>.
 
 extern crate bdcs;
+#[macro_use] extern crate pretty_assertions;
 extern crate rusqlite;
 
 use rusqlite::Connection;

--- a/tests/depclose.rs
+++ b/tests/depclose.rs
@@ -18,6 +18,7 @@
 // along with bdcs-api-server.  If not, see <http://www.gnu.org/licenses/>.
 
 extern crate bdcs;
+#[macro_use] extern crate pretty_assertions;
 
 use bdcs::depclose::*;
 

--- a/tests/mock_tests.rs
+++ b/tests/mock_tests.rs
@@ -20,6 +20,7 @@
 
 extern crate bdcs;
 #[macro_use] extern crate lazy_static;
+#[macro_use] extern crate pretty_assertions;
 extern crate rocket;
 extern crate toml;
 

--- a/tests/rpm.rs
+++ b/tests/rpm.rs
@@ -18,6 +18,7 @@
 // along with bdcs-api-server.  If not, see <http://www.gnu.org/licenses/>.
 
 extern crate bdcs;
+#[macro_use] extern crate pretty_assertions;
 
 use bdcs::rpm::{self, EVR, ReqOperator, Requirement, vercmp};
 use std::cmp::Ordering;


### PR DESCRIPTION
This colorizes the diffs when an assert_eq! fails, making it much easier
to find the changes in, for example, json strings.