### PR TITLE
Add DELETE to the list of methods allowed for CORS

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -151,7 +151,7 @@ impl<'r, R: Responder<'r>> Responder<'r> for CORS<R> {
         Response::build_from(try!(self.0.respond()))
             .header(header::AccessControlAllowOrigin::Any)
             .header(header::AccessControlAllowMethods(vec![
-                Method::Get, Method::Post, Method::Options]))
+                Method::Get, Method::Post, Method::Delete, Method::Options]))
             .header(header::AccessControlAllowHeaders(vec![
                 // Hyper uses the `unicase::Unicase` type to ensure comparisons are done
                 // case-insensitively. Here, we use `into()` to convert to one from a `&str`

--- a/src/api/v0.rs
+++ b/src/api/v0.rs
@@ -1361,6 +1361,17 @@ pub fn recipes_new_toml(recipe: TOML<Recipe>, repo: State<RecipeRepo>) -> CORS<J
 }
 
 
+/// The CORS system 'protects' the client via an OPTIONS request to make sure it is allowed
+///
+/// This returns an empty response, with the CORS headers set by [CORS](struct.CORS.html).
+// Rocket has a collision with Diesel so uses route instead
+//#[options("/recipes/new/")]
+#[route(OPTIONS, "/recipes/delete/<recipe_name>")]
+#[allow(unused_variables)]
+pub fn options_recipes_delete(recipe_name: &str) -> CORS<&'static str> {
+    CORS("")
+}
+
 /// Hold the JSON response for /recipes/new/
 #[derive(Debug, Serialize)]
 pub struct RecipesDeleteResponse {

--- a/src/bin/bdcs-api-server.rs
+++ b/src/bin/bdcs-api-server.rs
@@ -156,7 +156,7 @@ fn main() {
                                    v0::recipes_changes_default, v0::recipes_changes_filter,
                                    v0::recipes_diff,
                                    v0::options_recipes_new, v0::recipes_new_json, v0::recipes_new_toml,
-                                   v0::recipes_delete,
+                                   v0::options_recipes_delete, v0::recipes_delete,
                                    v0::recipes_undo,
                                    v0::recipes_depsolve])
         .mount("/api/mock/", routes![mock::static_route, mock::static_route_filter,


### PR DESCRIPTION
The browser only allows what we tell it to allow, without this you
cannot DELETE /recipes/delete/<recipe>