### PR TITLE
Add /version API route and inject git commit details into build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ VOLUME /mddb /bdcs-recipes /mockfiles
 ## Do the things more likely to change below here. ##
 ## Run rustup update to pick up the latest nightly ##
 COPY . /bdcs-api-rs/
-RUN cd /bdcs-api-rs/ && rm -rf ./target/ Cargo.lock && rustup update && cargo build && cargo doc
+RUN cd /bdcs-api-rs/ && rm -rf ./target/ Cargo.lock && rustup update && make bdcs-api doc

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,24 @@
+default: all
+
+all: bdcs-api
+
+bdcs-api:
+	GIT_COMMIT=$(shell git describe) cargo build
+
+doc: bdcs-api
+	cargo doc
+
+clean:
+	cargo clean
+
 clippy:
 	command -v cargo-clippy >/dev/null 2>&1 || cargo install clippy
 	cargo clippy -- --cfg test -D warnings -A doc-markdown
 
-test:
+test: bdcs-api
 	RUST_BACKTRACE=1 cargo test --features "strict"
 
-depclose-travis:
-	RUST_BACKTRACE=1 cargo build
+depclose-travis: bdcs-api
 	wget https://s3.amazonaws.com/atodorov/metadata_centos7.db.gz
 	gunzip ./metadata_centos7.db.gz
 	METADATA_DB=./metadata_centos7.db make -C ./tests/depclose-integration/ test

--- a/src/api/v0.rs
+++ b/src/api/v0.rs
@@ -9,6 +9,9 @@
 //! # v0 API routes
 //!
 //! * `/api/v0/test`
+//! * `/api/v0/version`
+//!  - Return the build and api version for the running code.
+//!  - [Example JSON](fn.version.html#examples)
 //! * `/api/v0/isos`
 //! * `/api/v0/compose`
 //! * `/api/v0/compose/cancel`
@@ -128,6 +131,41 @@ use api::toml::TOML;
 pub fn test() -> CORS<&'static str> {
     info!("/test");
    CORS("API v0 test")
+}
+
+
+/// Structure to hold the version details
+#[derive(Serialize)]
+pub struct BuildVersion {
+    build: String,
+    api:   u64
+}
+
+/// Return the build version of the API
+///
+/// # Response
+///
+/// * a JSON object
+///
+/// # Examples
+///
+/// ```json
+/// {
+///     "build": "v0.3.0-67-g485875e",
+///     "api": 0
+/// }
+/// ```
+#[get("/version")]
+pub fn version() -> CORS<JSON<BuildVersion>> {
+    let version = match option_env!("GIT_COMMIT") {
+        Some(version) => version,
+        None          => crate_version!()
+    };
+
+    CORS(JSON(BuildVersion {
+        build:   version.to_string(),
+        api:     0
+    }))
 }
 
 

--- a/src/bin/bdcs-api-server.rs
+++ b/src/bin/bdcs-api-server.rs
@@ -69,9 +69,14 @@ use slog::DrainExt;
 
 /// Process Command Line Arguments and Serve the http API
 fn main() {
+    let version = match option_env!("GIT_COMMIT") {
+        Some(version) => version,
+        None          => crate_version!()
+    };
+
     let matches = App::new("bdcs-api")
                             .about("A REST API on top of the BDCS")
-                            .version(crate_version!())
+                            .version(version)
                             .arg(Arg::with_name("host")
                                         .long("host")
                                         .value_name("HOSTNAME|IP")
@@ -131,7 +136,7 @@ fn main() {
     let log = slog::Logger::root(slog::duplicate(term_drain, file_drain).fuse(), o!());
     slog_scope::set_global_logger(log);
 
-    info!(format!("BDCS API v{} started", crate_version!()));
+    info!(format!("BDCS API {} started", version));
     info!("Config:"; "rocket_config" => format!("{:?}", rocket_config));
 
     // Import the recipes from recipe_path into master branch of the git repository
@@ -141,7 +146,8 @@ fn main() {
     }
 
     rocket::ignite()
-        .mount("/api/v0/", routes![ v0::test, v0::isos, v0::compose, v0::compose_types, v0::compose_cancel,
+        .mount("/api/v0/", routes![v0::test, v0::version,
+                                   v0::isos, v0::compose, v0::compose_types, v0::compose_cancel,
                                    v0::compose_status, v0::compose_status_id, v0::compose_log,
                                    v0::projects_list_default, v0::projects_list_filter,
                                    v0::projects_info,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 #![plugin(rocket_codegen)]
 
 extern crate chrono;
+#[macro_use] extern crate clap;
 extern crate git2;
 extern crate glob;
 extern crate hyper;


### PR DESCRIPTION
If the project is built using make it will include the git describe
output as the version (and fall back to the crate version if it isn't).

/api/v0/version will return JSON with the build version and API version
included.