### PR TITLE
Dockerfile: drop the version number from clippy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME /mddb /bdcs-recipes /mockfiles
 # testing dependencies which don't belong here but this
 # is the best place to avoid executing these steps on every single build
 # when intermediate container cache is available
-RUN cargo install clippy --vers 0.0.151
+RUN cargo install clippy
 RUN dnf --setopt=deltarpm=0 --verbose -y install \
     pylint python-toml python-nose-parameterized \
     elfutils-devel binutils-devel &&             \

--- a/src/bin/bdcs-api-server.rs
+++ b/src/bin/bdcs-api-server.rs
@@ -48,7 +48,6 @@
 extern crate bdcs;
 #[macro_use] extern crate clap;
 extern crate rocket;
-extern crate rusqlite;
 #[macro_use] extern crate slog;
 extern crate slog_json;
 #[macro_use] extern crate slog_scope;

--- a/src/bin/depclose.rs
+++ b/src/bin/depclose.rs
@@ -1,7 +1,6 @@
 extern crate bdcs;
 extern crate r2d2;
 extern crate r2d2_sqlite;
-extern crate rusqlite;
 
 use bdcs::db::*;
 use bdcs::depclose::*;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1185,7 +1185,7 @@ pub fn get_projects_details(conn: &Connection, projects: &[&str]) -> rusqlite::R
     for project_name in projects {
         let projs = match get_projects_name(conn, project_name, 0, i64::max_value()) {
             Ok((_, p)) => p,
-            Err(_) => { continue; }
+            Err(_) => vec![]
         };
 
         for proj in projs  {


### PR DESCRIPTION
This causes the build to fail when the compiler version is changed to
one that doesn't support the old version of clippy.

Installing without the version should be ok, it will be rebuilt when the
compiler nightly version is changed, and the clippy layer will remain
valid until the next compiler version.