### PR TITLE
Add /api/v0/status route

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -104,6 +104,7 @@ use hyper::method::Method;
 use rocket::http::hyper::header;
 use rocket::http::Status;
 use rocket::response::{self, Responder, Response};
+use rusqlite;
 
 use recipe::RecipeError;
 
@@ -176,6 +177,7 @@ impl<'r, R: Responder<'r>> Responder<'r> for CORS<R> {
 pub enum ApiError {
     NotFound,
     InternalServerError,
+    SQLiteError,
 }
 
 impl fmt::Display for ApiError {
@@ -183,6 +185,7 @@ impl fmt::Display for ApiError {
         match *self {
             ApiError::NotFound => f.write_str("NotFound"),
             ApiError::InternalServerError => f.write_str("InternalServerError"),
+            ApiError::SQLiteError => f.write_str("SQLiteError"),
         }
     }
 }
@@ -192,6 +195,7 @@ impl StdError for ApiError {
         match *self {
             ApiError::NotFound => "Not found",
             ApiError::InternalServerError => "Internal server error",
+            ApiError::SQLiteError => "SQLite error",
         }
     }
 }
@@ -209,5 +213,11 @@ impl<'r> Responder<'r> for ApiError {
 impl From<RecipeError> for ApiError {
     fn from(_err: RecipeError) -> ApiError {
         ApiError::NotFound
+    }
+}
+
+impl From<rusqlite::Error> for ApiError {
+    fn from(_err: rusqlite::Error) -> ApiError {
+        ApiError::SQLiteError
     }
 }

--- a/src/bin/bdcs-api-server.rs
+++ b/src/bin/bdcs-api-server.rs
@@ -178,7 +178,8 @@ fn main() {
                                    v0::options_recipes_delete, v0::recipes_delete,
                                    v0::recipes_undo,
                                    v0::recipes_depsolve,
-                                   v0::options_recipes_tag, v0::recipes_tag])
+                                   v0::options_recipes_tag, v0::recipes_tag,
+                                   v0::status])
         .mount("/api/mock/", routes![mock::static_route, mock::static_route_filter,
                                      mock::static_route_param, mock::static_route_param_filter,
                                      mock::static_route_action, mock::static_route_action_filter])


### PR DESCRIPTION
This will return a JSON response:

{"build":"0.5.0","api":0,"db_version":1,"schema_version":0,"db_supported":false}

The db_version is the highest db schema version supported. The
schema_version is the version of the current metadata.db database.
db_supported is set to true if the metadata.db schema is supported by
the API.